### PR TITLE
Feature 74

### DIFF
--- a/inc/common.inc.sh
+++ b/inc/common.inc.sh
@@ -1280,7 +1280,8 @@ function displayChangelogSection () {
 #    ne se sont pas écoulés depuis le dernier test.
 #
 function autoupdate () {
-    local is_forced="$1"
+    [ $1 = 'force' ] && local is_forced="$1" || local is_forced=""
+    shift
     cd "$TWGIT_ROOT_DIR"
     if git rev-parse --git-dir 1>/dev/null 2>&1; then
         [ ! -f "$TWGIT_UPDATE_PATH" ] && touch "$TWGIT_UPDATE_PATH"
@@ -1353,7 +1354,11 @@ then consequently update '<b>$TWGIT_CONF_DIR/twgit.sh</b>':";
 
             # Invite :
             if [ "$answer" = "Y" ] || [ "$answer" = "y" ]; then
-                [ -z "$is_forced" ] && echo 'Thank you for re-entering your request.'
+                if [ -z "$is_forced" ]; then
+                    echo 'Continuing with your initial request...'
+                    cd - 1>/dev/null
+                    $TWGIT_EXEC $*
+                fi
                 exit 0
             fi
         fi

--- a/twgit
+++ b/twgit
@@ -183,7 +183,7 @@ function main () {
     fi
 }
 
-[ "$1" != "update" ] && [ "$TWGIT_UPDATE_AUTO" = "1" ] && autoupdate
+[ "$1" != "update" ] && [ "$TWGIT_UPDATE_AUTO" = "1" ] && autoupdate 'no-force' $*
 assert_git_configured
 assert_connectors_well_configured
 main "$@"


### PR DESCRIPTION
Now, when an update comes out, you can perform the autoupdate and don't need to launch for a seconde time your previous request.

You'll see the message "Continuing with your initial request..." at the end of the update.

![Capture du 2013-01-11 11:10:15](https://f.cloud.github.com/assets/2511984/59614/684ed570-5bd7-11e2-8041-bc4db73115fe.png)
