### PR TITLE
Improve copy/paste of git command to apply last tag in current branch

### DIFF
--- a/inc/common.inc.sh
+++ b/inc/common.inc.sh
@@ -1203,7 +1203,7 @@ function alert_old_branch () {
         msg="${msg} not merged into this branch:"
         [ "$nb_tags_no_merged" -eq "$TWGIT_MAX_RETRIEVE_TAGS_NOT_MERGED" ] && msg="${msg} at least"
         msg="${msg} $(displayInterval "$tags_not_merged")."
-        [ "$2" = 'with-help' ] && msg="${msg} If need be: git merge --no-ff $(get_last_tag), then: git push $TWGIT_ORIGIN $branch"
+        [ "$2" = 'with-help' ] && msg="${msg} If need be: git merge --no-ff $(get_last_tag) && git push $TWGIT_ORIGIN $branch"
         CUI_displayMsg warning "$msg"
     fi
 }


### PR DESCRIPTION
Replace in the comment to apply last tag, ", then:" by "&&".
