### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/inc/TwgitTestCase.php
+++ b/tests/inc/TwgitTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Classe parente des tests Twgit, permet de faciliter les interactions entre PHP, Shell et Git.
  *
@@ -7,7 +9,7 @@
  * @author Geoffroy Aubry <geoffroy.aubry@hi-media.com>
  * @author Geoffroy Letournel <gletournel@hi-media.com>
  */
-class TwgitTestCase extends PHPUnit_Framework_TestCase
+class TwgitTestCase extends TestCase
 {
     /**
      * The name of the Git "stable" branch


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).